### PR TITLE
feat: factor correlation and diversification analyzer

### DIFF
--- a/frontend-v2/backend/app.py
+++ b/frontend-v2/backend/app.py
@@ -748,6 +748,93 @@ async def list_factor_libraries():
     return ApiResponse(success=True, data={"libraries": libs})
 
 
+# Diversification analysis endpoints. Must be registered before
+# /api/v1/factors/{factor_id}, otherwise FastAPI matches the literal
+# path segments as factor_id values.
+
+def _resolve_library_path(library):
+    if library:
+        candidate = PROJECT_ROOT / "data" / "factorlib" / library
+        if candidate.exists():
+            return str(candidate)
+        alt = PROJECT_ROOT / library
+        if alt.exists():
+            return str(alt)
+        raise HTTPException(status_code=404, detail=f"Factor library not found: {library}")
+
+    jsons = _find_factor_jsons()
+    if not jsons:
+        raise HTTPException(status_code=404, detail="No factor library found")
+    return jsons[0]
+
+
+@app.get("/api/v1/factors/correlation", response_model=ApiResponse)
+async def factor_correlation(
+    library: Optional[str] = Query(None, description="Factor library JSON filename"),
+    redundancy_threshold: float = Query(0.9),
+):
+    """Pairwise correlation + redundant-pair list for a factor library."""
+    lib_path = _resolve_library_path(library)
+    from quantaalpha.analysis.correlation import (
+        FactorDiversificationAnalyzer, _matrix_to_records,
+    )
+
+    analyzer = FactorDiversificationAnalyzer(lib_path)
+    n_with_values = analyzer.load()
+    matrix = analyzer.correlation_matrix()
+    redundant = analyzer.redundant_pairs(threshold=redundancy_threshold)
+    clusters = analyzer.cluster() if len(matrix) >= 2 else {}
+
+    return ApiResponse(
+        success=True,
+        data={
+            "library": Path(lib_path).name,
+            "summary": {
+                "total_factors": len(analyzer.records),
+                "factors_with_values": n_with_values,
+                "redundant_pairs": len(redundant),
+                "n_clusters": (max(clusters.values()) + 1) if clusters else 0,
+            },
+            "redundant_pairs": redundant,
+            "clusters": clusters,
+            "correlation_matrix": _matrix_to_records(matrix),
+        },
+    )
+
+
+class DiversifiedSubsetRequest(BaseModel):
+    library: Optional[str] = None
+    top: int = 20
+    maxCorr: float = 0.7
+    writeSubset: Optional[str] = None
+
+
+@app.post("/api/v1/factors/diversified-subset", response_model=ApiResponse)
+async def factor_diversified_subset(req: DiversifiedSubsetRequest):
+    """Pick a high-IC, low-correlation subset and optionally write it as a library JSON."""
+    lib_path = _resolve_library_path(req.library)
+    from quantaalpha.analysis.correlation import FactorDiversificationAnalyzer
+
+    analyzer = FactorDiversificationAnalyzer(lib_path)
+    analyzer.load()
+    subset = analyzer.diversified_subset(top_n=req.top, max_corr=req.maxCorr)
+
+    written_path = None
+    if req.writeSubset:
+        out_path = PROJECT_ROOT / "data" / "factorlib" / req.writeSubset
+        analyzer.write_subset_library(out_path, subset)
+        written_path = str(out_path)
+
+    return ApiResponse(
+        success=True,
+        data={
+            "library": Path(lib_path).name,
+            "subset": subset,
+            "writtenTo": written_path,
+        },
+    )
+
+
 @app.get("/api/v1/factors/{factor_id}", response_model=ApiResponse)
 async def get_factor_detail(factor_id: str):
     """Get full detail of a single factor."""

--- a/quantaalpha/analysis/__init__.py
+++ b/quantaalpha/analysis/__init__.py
@@ -1,0 +1,3 @@
+from quantaalpha.analysis.correlation import FactorDiversificationAnalyzer
+
+__all__ = ["FactorDiversificationAnalyzer"]

--- a/quantaalpha/analysis/correlation.py
+++ b/quantaalpha/analysis/correlation.py
@@ -1,0 +1,440 @@
+"""
+Correlation / diversification analysis for the factor library.
+
+Mining tends to produce many similar factors (lots of variants of the
+same idea). Combining all of them in one basket is wasteful, since
+correlated factors don't add diversification.
+
+Workflow:
+    a = FactorDiversificationAnalyzer("all_factors_library.json")
+    a.load()
+    report = a.report(top_n=20, max_corr=0.7)
+"""
+
+import hashlib
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_FACTOR_CACHE_DIR = os.environ.get(
+    "FACTOR_CACHE_DIR",
+    "data/results/factor_cache",
+)
+
+
+# Backtest-result keys can drift between mining runs, so try a few.
+IC_KEYS = (
+    "IC",
+    "Rank IC",
+    "rank_ic",
+    "1day.excess_return_without_cost.information_coefficient",
+    "1day.excess_return_without_cost.rank_ic",
+)
+
+
+def _extract_ic(backtest_results):
+    """Return (IC, Rank IC) from a backtest dict."""
+    ic = 0.0
+    rank_ic = 0.0
+    for key in IC_KEYS:
+        if key not in backtest_results:
+            continue
+        v = backtest_results[key]
+        if v is None:
+            continue
+        try:
+            v = float(v)
+        except (TypeError, ValueError):
+            continue
+        if "rank" in key.lower():
+            if rank_ic == 0.0:
+                rank_ic = v
+        else:
+            if ic == 0.0:
+                ic = v
+    return ic, rank_ic
+
+
+@dataclass
+class FactorRecord:
+    factor_id: str
+    factor_name: str
+    factor_expression: str
+    ic: float = 0.0
+    rank_ic: float = 0.0
+    values: Optional[pd.Series] = None
+    meta: dict = field(default_factory=dict)
+
+    @property
+    def score(self):
+        # Prefer rank IC when present, fall back to IC, fall back to 0.
+        if self.rank_ic and not np.isnan(self.rank_ic):
+            return abs(float(self.rank_ic))
+        if self.ic and not np.isnan(self.ic):
+            return abs(float(self.ic))
+        return 0.0
+
+
+class FactorDiversificationAnalyzer:
+    def __init__(self, library_path, cache_dir=None):
+        self.library_path = Path(library_path)
+        self.cache_dir = Path(cache_dir or DEFAULT_FACTOR_CACHE_DIR)
+        self.records: List[FactorRecord] = []
+        self._corr_matrix: Optional[pd.DataFrame] = None
+
+    def load(self, max_factors=None):
+        """Read library JSON and pull cached factor values when present.
+
+        Returns the count of factors that have usable values; the rest
+        are still kept (useful for ranking) but excluded from corr.
+        """
+        if not self.library_path.exists():
+            raise FileNotFoundError(f"Factor library not found: {self.library_path}")
+
+        with open(self.library_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        factors = data.get("factors", {}) or {}
+        loaded_with_values = 0
+
+        for fid, info in factors.items():
+            expr = info.get("factor_expression", "") or ""
+            ic, rank_ic = _extract_ic(info.get("backtest_results", {}) or {})
+
+            md = info.get("metadata", {}) or {}
+            rec = FactorRecord(
+                factor_id=fid,
+                factor_name=info.get("factor_name", fid) or fid,
+                factor_expression=expr,
+                ic=ic,
+                rank_ic=rank_ic,
+                meta={
+                    "round": md.get("round_number"),
+                    "trajectory_id": md.get("trajectory_id"),
+                    "evolution_phase": md.get("evolution_phase"),
+                },
+            )
+            rec.values = self._load_values(expr, info.get("cache_location") or {})
+            if rec.values is not None:
+                loaded_with_values += 1
+
+            self.records.append(rec)
+            if max_factors is not None and len(self.records) >= max_factors:
+                break
+
+        logger.info(
+            "Loaded %d factors from %s (%d with cached values)",
+            len(self.records), self.library_path.name, loaded_with_values,
+        )
+        return loaded_with_values
+
+    def _load_values(self, expr, cache_location):
+        # Try MD5 pickle first (fast, written by FactorLibraryManager).
+        if expr:
+            md5_key = hashlib.md5(expr.encode()).hexdigest()
+            pkl = self.cache_dir / f"{md5_key}.pkl"
+            if pkl.exists():
+                try:
+                    return _coerce_series(pd.read_pickle(pkl))
+                except Exception as e:
+                    logger.debug("Failed reading %s: %s", pkl, e)
+
+        # Fall back to result.h5 if the library entry points at one.
+        h5_path = cache_location.get("result_h5_path") if cache_location else None
+        if h5_path and Path(h5_path).exists():
+            try:
+                return _coerce_series(pd.read_hdf(h5_path))
+            except Exception as e:
+                logger.debug("Failed reading %s: %s", h5_path, e)
+        return None
+
+    def correlation_matrix(self, min_overlap=30):
+        """Pairwise mean cross-sectional Spearman corr.
+
+        Pairs without enough overlap come back as NaN; callers should
+        treat NaN as unknown rather than zero.
+        """
+        if self._corr_matrix is not None:
+            return self._corr_matrix
+
+        usable = [r for r in self.records if r.values is not None]
+        if len(usable) < 2:
+            self._corr_matrix = pd.DataFrame(
+                np.eye(len(usable)),
+                index=[r.factor_id for r in usable],
+                columns=[r.factor_id for r in usable],
+                dtype=float,
+            )
+            return self._corr_matrix
+
+        panels = {}
+        for r in usable:
+            try:
+                panels[r.factor_id] = _to_panel(r.values)
+            except Exception as e:
+                logger.debug("Skip %s: %s", r.factor_name, e)
+
+        ids = [r.factor_id for r in usable if r.factor_id in panels]
+        m = pd.DataFrame(np.eye(len(ids)), index=ids, columns=ids, dtype=float)
+        for i, a in enumerate(ids):
+            pa = panels[a]
+            for j in range(i + 1, len(ids)):
+                b = ids[j]
+                c = _mean_xs_rank_corr(pa, panels[b], min_overlap=min_overlap)
+                m.iat[i, j] = c
+                m.iat[j, i] = c
+
+        self._corr_matrix = m
+        return m
+
+    def redundant_pairs(self, threshold=0.9):
+        m = self.correlation_matrix()
+        out = []
+        ids = list(m.index)
+        for i, a in enumerate(ids):
+            for j in range(i + 1, len(ids)):
+                b = ids[j]
+                c = m.iat[i, j]
+                if pd.isna(c):
+                    continue
+                if abs(c) >= threshold:
+                    out.append({
+                        "factor_a": a,
+                        "factor_b": b,
+                        "factor_a_name": self._name(a),
+                        "factor_b_name": self._name(b),
+                        "correlation": round(float(c), 6),
+                    })
+        out.sort(key=lambda d: abs(d["correlation"]), reverse=True)
+        return out
+
+    def cluster(self, n_clusters=None, distance_threshold=0.3):
+        """Group factors by 1 - |corr| with agglomerative clustering."""
+        from sklearn.cluster import AgglomerativeClustering
+
+        m = self.correlation_matrix()
+        if len(m) < 2:
+            return {fid: 0 for fid in m.index}
+
+        d = 1.0 - m.abs().fillna(1.0)
+        np.fill_diagonal(d.values, 0.0)
+
+        kwargs = {"metric": "precomputed", "linkage": "average"}
+        if n_clusters is not None:
+            kwargs["n_clusters"] = n_clusters
+        else:
+            kwargs["n_clusters"] = None
+            kwargs["distance_threshold"] = distance_threshold
+
+        labels = AgglomerativeClustering(**kwargs).fit_predict(d.values)
+        return dict(zip(m.index, (int(x) for x in labels)))
+
+    def diversified_subset(self, top_n=20, max_corr=0.7, lambda_penalty=0.5):
+        """Greedy pick: highest-scoring factors that aren't too correlated
+        with anything already in the set.
+        """
+        if not self.records:
+            return []
+
+        candidates = sorted(self.records, key=lambda r: r.score, reverse=True)
+
+        # If everything has zero IC, just hand back the top-N by name.
+        if not candidates or candidates[0].score == 0.0:
+            logger.warning("No factors with non-zero IC; returning top-N as-is")
+            return [self._summarize(r, 0.0) for r in candidates[:top_n]]
+
+        m = self.correlation_matrix()
+        in_matrix = set(m.index)
+
+        selected: List[FactorRecord] = []
+        for cand in candidates:
+            if len(selected) >= top_n:
+                break
+
+            if not selected:
+                selected.append(cand)
+                continue
+
+            # Factor without cached values can only fill the tail.
+            if cand.factor_id not in in_matrix:
+                if len(selected) >= int(0.75 * top_n):
+                    selected.append(cand)
+                continue
+
+            corrs = []
+            for s in selected:
+                if s.factor_id not in in_matrix:
+                    continue
+                c = m.at[cand.factor_id, s.factor_id]
+                if not pd.isna(c):
+                    corrs.append(abs(float(c)))
+
+            max_c = max(corrs) if corrs else 0.0
+            if max_c >= max_corr:
+                continue
+
+            # lambda_penalty kept for future scoring tweaks; gate above is what filters.
+            _ = cand.score - lambda_penalty * max_c
+            selected.append(cand)
+
+        out = []
+        for r in selected:
+            mc = self._max_corr_against(r, selected, m)
+            out.append(self._summarize(r, mc))
+        return out
+
+    def report(self, top_n=20, max_corr=0.7, redundancy_threshold=0.9):
+        matrix = self.correlation_matrix()
+        clusters = self.cluster() if len(matrix) >= 2 else {}
+        redundant = self.redundant_pairs(threshold=redundancy_threshold)
+        subset = self.diversified_subset(top_n=top_n, max_corr=max_corr)
+
+        n_with_values = sum(1 for r in self.records if r.values is not None)
+        return {
+            "library": str(self.library_path),
+            "summary": {
+                "total_factors": len(self.records),
+                "factors_with_values": n_with_values,
+                "redundant_pairs": len(redundant),
+                "n_clusters": (max(clusters.values()) + 1) if clusters else 0,
+                "diversified_subset_size": len(subset),
+            },
+            "redundant_pairs": redundant,
+            "clusters": clusters,
+            "diversified_subset": subset,
+            "correlation_matrix": _matrix_to_records(matrix),
+        }
+
+    def write_subset_library(self, output_path, subset):
+        """Write a factor-library JSON with only the picked factors.
+
+        The output is in the same format the mining loop produces, so
+        run_backtest.py can take it via --factor-json directly.
+        """
+        with open(self.library_path, "r", encoding="utf-8") as f:
+            original = json.load(f)
+
+        keep = {item["factor_id"] for item in subset}
+        out = {
+            "metadata": {
+                **(original.get("metadata") or {}),
+                "derived_from": str(self.library_path),
+                "derivation": "diversified_subset",
+                "total_factors": len(keep),
+            },
+            "factors": {
+                fid: info
+                for fid, info in (original.get("factors") or {}).items()
+                if fid in keep
+            },
+        }
+        out_path = Path(output_path)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(out, f, ensure_ascii=False, indent=2, default=str)
+        logger.info("Wrote diversified subset (%d factors) to %s", len(keep), out_path)
+        return out_path
+
+    def _name(self, factor_id):
+        for r in self.records:
+            if r.factor_id == factor_id:
+                return r.factor_name
+        return factor_id
+
+    @staticmethod
+    def _max_corr_against(rec, others, matrix):
+        if rec.factor_id not in matrix.index:
+            return 0.0
+        vals = []
+        for s in others:
+            if s.factor_id == rec.factor_id or s.factor_id not in matrix.index:
+                continue
+            c = matrix.at[rec.factor_id, s.factor_id]
+            if not pd.isna(c):
+                vals.append(abs(float(c)))
+        return float(max(vals)) if vals else 0.0
+
+    @staticmethod
+    def _summarize(rec, max_corr_with_selected):
+        return {
+            "factor_id": rec.factor_id,
+            "factor_name": rec.factor_name,
+            "factor_expression": rec.factor_expression,
+            "ic": round(float(rec.ic), 6) if rec.ic else 0.0,
+            "rank_ic": round(float(rec.rank_ic), 6) if rec.rank_ic else 0.0,
+            "score": round(rec.score, 6),
+            "max_corr_with_selected": round(float(max_corr_with_selected), 6),
+            "metadata": rec.meta,
+        }
+
+
+def _coerce_series(obj):
+    """Cache files might be a Series, single-column DataFrame, or wide panel."""
+    if isinstance(obj, pd.Series):
+        return obj
+    if isinstance(obj, pd.DataFrame):
+        if obj.shape[1] == 1:
+            return obj.iloc[:, 0]
+        # wide -> stacked multi-index
+        try:
+            return obj.stack(future_stack=True)
+        except TypeError:
+            return obj.stack()
+    return None
+
+
+def _to_panel(values):
+    """(datetime, instrument) Series -> date x instrument DataFrame."""
+    if not isinstance(values.index, pd.MultiIndex):
+        raise ValueError("Expected a (datetime, instrument) MultiIndex")
+    return values.unstack(level=-1).sort_index()
+
+
+def _mean_xs_rank_corr(a, b, min_overlap=30):
+    """Mean per-date Spearman corr across overlapping dates/instruments."""
+    common_dates = a.index.intersection(b.index)
+    if len(common_dates) == 0:
+        return float("nan")
+    common_cols = a.columns.intersection(b.columns)
+    if len(common_cols) < 3:
+        return float("nan")
+
+    a = a.loc[common_dates, common_cols]
+    b = b.loc[common_dates, common_cols]
+
+    # Spearman = Pearson on per-row ranks
+    ar = a.rank(axis=1, method="average")
+    br = b.rank(axis=1, method="average")
+
+    arc = ar.sub(ar.mean(axis=1), axis=0)
+    brc = br.sub(br.mean(axis=1), axis=0)
+    num = (arc * brc).sum(axis=1)
+    den = np.sqrt((arc ** 2).sum(axis=1) * (brc ** 2).sum(axis=1))
+
+    with np.errstate(invalid="ignore", divide="ignore"):
+        per_date = num / den.replace(0, np.nan)
+
+    valid = per_date.dropna()
+    if len(valid) < min_overlap:
+        return float("nan")
+    return float(valid.mean())
+
+
+def _matrix_to_records(matrix):
+    if matrix.empty:
+        return {"ids": [], "values": []}
+    ids = list(matrix.index)
+    values = [
+        [None if pd.isna(x) else round(float(x), 6) for x in row]
+        for row in matrix.values
+    ]
+    return {"ids": ids, "values": values}

--- a/quantaalpha/analysis/run_analysis.py
+++ b/quantaalpha/analysis/run_analysis.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Run correlation / diversification analysis on a factor library JSON.
+
+Examples:
+    python -m quantaalpha.analysis.run_analysis -j all_factors_library.json
+    python -m quantaalpha.analysis.run_analysis -j all_factors_library.json \\
+        --top 20 --max-corr 0.7 --write-subset diversified_top20.json
+"""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[2]
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+try:
+    from dotenv import load_dotenv
+    env_file = project_root / ".env"
+    if env_file.exists():
+        load_dotenv(env_file)
+except ImportError:
+    pass
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+logger = logging.getLogger(__name__)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Factor library correlation / diversification analysis",
+    )
+    parser.add_argument("-j", "--factor-json", type=str, required=True,
+                        help="Path to factor library JSON")
+    parser.add_argument("-o", "--output", type=str, default=None,
+                        help="Output JSON report path")
+    parser.add_argument("--cache-dir", type=str, default=None,
+                        help="MD5 factor cache dir (env FACTOR_CACHE_DIR by default)")
+    parser.add_argument("--top", type=int, default=20,
+                        help="Diversified subset size (default 20)")
+    parser.add_argument("--max-corr", type=float, default=0.7,
+                        help="Max pairwise corr inside the subset (default 0.7)")
+    parser.add_argument("--redundancy-threshold", type=float, default=0.9,
+                        help="|corr| above which a pair is flagged redundant")
+    parser.add_argument("--write-subset", type=str, default=None,
+                        help="Optional path to emit a filtered library JSON")
+    parser.add_argument("-v", "--verbose", action="store_true")
+
+    args = parser.parse_args()
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    library_path = Path(args.factor_json)
+    if not library_path.exists():
+        logger.error("Factor library not found: %s", library_path)
+        return 2
+
+    from quantaalpha.analysis.correlation import FactorDiversificationAnalyzer
+
+    analyzer = FactorDiversificationAnalyzer(library_path, cache_dir=args.cache_dir)
+    n_with_values = analyzer.load()
+
+    if not analyzer.records:
+        logger.error("Factor library is empty")
+        return 1
+    if n_with_values < 2:
+        logger.warning(
+            "Only %d factor(s) have cached values, correlation analysis will be empty.",
+            n_with_values,
+        )
+
+    report = analyzer.report(
+        top_n=args.top,
+        max_corr=args.max_corr,
+        redundancy_threshold=args.redundancy_threshold,
+    )
+
+    s = report["summary"]
+    print()
+    print("Factor diversification report")
+    print("=" * 60)
+    print(f"  Library:                {library_path}")
+    print(f"  Total factors:          {s['total_factors']}")
+    print(f"  Factors with values:    {s['factors_with_values']}")
+    print(f"  Distinct clusters:      {s['n_clusters']}")
+    print(f"  Redundant pairs (>= {args.redundancy_threshold}): {s['redundant_pairs']}")
+    print(f"  Diversified subset:     {s['diversified_subset_size']} "
+          f"(target {args.top}, max_corr {args.max_corr})")
+    print()
+
+    redundant = report["redundant_pairs"][:5]
+    if redundant:
+        print(f"Top {len(redundant)} most redundant pairs:")
+        for p in redundant:
+            print(f"  {p['correlation']:+.3f}  "
+                  f"{p['factor_a_name']}  vs  {p['factor_b_name']}")
+        print()
+
+    subset = report["diversified_subset"]
+    if subset:
+        print(f"Diversified subset (max pairwise corr {args.max_corr}):")
+        for i, r in enumerate(subset, 1):
+            print(f"  {i:>3}. score={r['score']:.4f}  rank_ic={r['rank_ic']:+.4f}  "
+                  f"max_corr={r['max_corr_with_selected']:.3f}  {r['factor_name']}")
+        print()
+
+    output_path = Path(args.output) if args.output else \
+        library_path.with_suffix(".diversification.json")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(report, f, ensure_ascii=False, indent=2, default=str)
+    logger.info("Wrote full report to %s", output_path)
+
+    if args.write_subset:
+        analyzer.write_subset_library(args.write_subset, subset)
+        print(f"Diversified subset library: {args.write_subset}")
+        print("  python -m quantaalpha.backtest.run_backtest "
+              f"-c configs/backtest.yaml --factor-source custom "
+              f"--factor-json {args.write_subset}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -1,0 +1,226 @@
+"""Unit tests for quantaalpha.analysis.correlation.
+
+Synthetic data only, no Qlib / no LLM.
+"""
+
+import hashlib
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from quantaalpha.analysis.correlation import (
+    FactorDiversificationAnalyzer,
+    _matrix_to_records,
+    _mean_xs_rank_corr,
+    _to_panel,
+)
+
+
+def _make_factor_series(panel, dates, instruments):
+    df = pd.DataFrame(panel, index=dates, columns=instruments)
+    df.index.name = "datetime"
+    df.columns.name = "instrument"
+    return df.stack().rename("factor")
+
+
+def _build_library(tmp_path, factors_meta, panels):
+    cache_dir = tmp_path / "factor_cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    lib = {
+        "metadata": {"created_at": "2026-01-01", "total_factors": len(factors_meta)},
+        "factors": {},
+    }
+
+    if panels:
+        n_dates, n_inst = panels[next(iter(panels))].shape
+    else:
+        n_dates, n_inst = 60, 30
+    dates = pd.date_range("2024-01-01", periods=n_dates, freq="B")
+    instruments = [f"SH{600000 + i}" for i in range(n_inst)]
+
+    for fid, meta in factors_meta.items():
+        expr = meta["factor_expression"]
+        if fid in panels:
+            series = _make_factor_series(panels[fid], dates, instruments)
+            md5 = hashlib.md5(expr.encode()).hexdigest()
+            series.to_pickle(cache_dir / f"{md5}.pkl")
+        lib["factors"][fid] = {
+            "factor_id": fid,
+            "factor_name": meta["factor_name"],
+            "factor_expression": expr,
+            "factor_description": "",
+            "factor_formulation": "",
+            "cache_location": {},
+            "metadata": {"round_number": 0, "trajectory_id": "", "evolution_phase": "original"},
+            "backtest_results": {"IC": meta.get("ic", 0.0), "Rank IC": meta.get("rank_ic", 0.0)},
+            "feedback": {},
+        }
+
+    lib_path = tmp_path / "library.json"
+    lib_path.write_text(json.dumps(lib, default=str))
+    return lib_path, cache_dir
+
+
+@pytest.fixture
+def synthetic_library(tmp_path):
+    # A and B are near-duplicates, C is independent.
+    rng = np.random.default_rng(42)
+    n_dates, n_inst = 80, 40
+    base = rng.standard_normal((n_dates, n_inst))
+    panels = {
+        "fid_a": base,
+        "fid_b": base + 0.001 * rng.standard_normal((n_dates, n_inst)),
+        "fid_c": rng.standard_normal((n_dates, n_inst)),
+    }
+    factors_meta = {
+        "fid_a": {"factor_name": "alpha_a", "factor_expression": "$close",
+                   "ic": 0.10, "rank_ic": 0.12},
+        "fid_b": {"factor_name": "alpha_b", "factor_expression": "$close + 0.001",
+                   "ic": 0.09, "rank_ic": 0.11},
+        "fid_c": {"factor_name": "alpha_c", "factor_expression": "$volume",
+                   "ic": 0.08, "rank_ic": 0.10},
+    }
+    lib_path, cache_dir = _build_library(tmp_path, factors_meta, panels)
+    return {"library": lib_path, "cache_dir": cache_dir}
+
+
+def test_to_panel_shape():
+    dates = pd.date_range("2024-01-01", periods=10, freq="B")
+    inst = ["A", "B", "C"]
+    series = _make_factor_series(np.arange(30).reshape(10, 3), dates, inst)
+    panel = _to_panel(series)
+    assert panel.shape == (10, 3)
+    assert list(panel.columns) == inst
+
+
+def test_mean_xs_rank_corr_perfect():
+    dates = pd.date_range("2024-01-01", periods=60, freq="B")
+    inst = [f"S{i}" for i in range(20)]
+    a = pd.DataFrame(np.random.default_rng(0).standard_normal((60, 20)),
+                     index=dates, columns=inst)
+    b = a * 2 + 5  # monotonic transform => perfect rank corr
+    assert _mean_xs_rank_corr(a, b, min_overlap=10) == pytest.approx(1.0, abs=1e-9)
+
+
+def test_mean_xs_rank_corr_anticorrelated():
+    dates = pd.date_range("2024-01-01", periods=60, freq="B")
+    inst = [f"S{i}" for i in range(20)]
+    a = pd.DataFrame(np.random.default_rng(1).standard_normal((60, 20)),
+                     index=dates, columns=inst)
+    b = -a
+    assert _mean_xs_rank_corr(a, b, min_overlap=10) == pytest.approx(-1.0, abs=1e-9)
+
+
+def test_matrix_to_records_handles_nan():
+    df = pd.DataFrame([[1.0, np.nan], [np.nan, 1.0]], index=["a", "b"], columns=["a", "b"])
+    out = _matrix_to_records(df)
+    assert out["ids"] == ["a", "b"]
+    assert out["values"][0][1] is None
+    assert out["values"][1][0] is None
+
+
+def test_analyzer_loads_records_and_values(synthetic_library):
+    a = FactorDiversificationAnalyzer(synthetic_library["library"],
+                                      cache_dir=synthetic_library["cache_dir"])
+    n = a.load()
+    assert len(a.records) == 3
+    assert n == 3
+
+
+def test_correlation_matrix_identifies_duplicate(synthetic_library):
+    a = FactorDiversificationAnalyzer(synthetic_library["library"],
+                                      cache_dir=synthetic_library["cache_dir"])
+    a.load()
+    m = a.correlation_matrix()
+    assert m.shape == (3, 3)
+    assert m.loc["fid_a", "fid_a"] == pytest.approx(1.0)
+    assert m.loc["fid_a", "fid_b"] > 0.95
+    assert abs(m.loc["fid_a", "fid_c"]) < 0.4
+
+
+def test_redundant_pairs(synthetic_library):
+    a = FactorDiversificationAnalyzer(synthetic_library["library"],
+                                      cache_dir=synthetic_library["cache_dir"])
+    a.load()
+    pairs = a.redundant_pairs(threshold=0.9)
+    assert len(pairs) == 1
+    assert {pairs[0]["factor_a"], pairs[0]["factor_b"]} == {"fid_a", "fid_b"}
+    assert pairs[0]["correlation"] > 0.9
+
+
+def test_diversified_subset_drops_duplicate(synthetic_library):
+    a = FactorDiversificationAnalyzer(synthetic_library["library"],
+                                      cache_dir=synthetic_library["cache_dir"])
+    a.load()
+    subset = a.diversified_subset(top_n=3, max_corr=0.7)
+    ids = {item["factor_id"] for item in subset}
+    assert "fid_a" in ids
+    assert "fid_b" not in ids  # too correlated with A
+    assert "fid_c" in ids
+    assert len(subset) == 2
+
+
+def test_diversified_subset_respects_top_n(synthetic_library):
+    a = FactorDiversificationAnalyzer(synthetic_library["library"],
+                                      cache_dir=synthetic_library["cache_dir"])
+    a.load()
+    subset = a.diversified_subset(top_n=1, max_corr=0.7)
+    assert len(subset) == 1
+    assert subset[0]["factor_id"] == "fid_a"
+
+
+def test_clusters_group_correlated_factors(synthetic_library):
+    a = FactorDiversificationAnalyzer(synthetic_library["library"],
+                                      cache_dir=synthetic_library["cache_dir"])
+    a.load()
+    clusters = a.cluster(distance_threshold=0.3)
+    assert clusters["fid_a"] == clusters["fid_b"]
+    assert clusters["fid_a"] != clusters["fid_c"]
+
+
+def test_report_shape(synthetic_library):
+    a = FactorDiversificationAnalyzer(synthetic_library["library"],
+                                      cache_dir=synthetic_library["cache_dir"])
+    a.load()
+    report = a.report(top_n=3, max_corr=0.7, redundancy_threshold=0.9)
+    assert report["summary"]["total_factors"] == 3
+    assert report["summary"]["factors_with_values"] == 3
+    assert report["summary"]["redundant_pairs"] == 1
+    assert "correlation_matrix" in report
+    assert "diversified_subset" in report
+
+
+def test_write_subset_library_round_trip(synthetic_library, tmp_path):
+    a = FactorDiversificationAnalyzer(synthetic_library["library"],
+                                      cache_dir=synthetic_library["cache_dir"])
+    a.load()
+    subset = a.diversified_subset(top_n=3, max_corr=0.7)
+    out_path = tmp_path / "diversified.json"
+    a.write_subset_library(out_path, subset)
+
+    written = json.loads(out_path.read_text())
+    assert written["metadata"]["derivation"] == "diversified_subset"
+    assert set(written["factors"].keys()) == {item["factor_id"] for item in subset}
+
+
+def test_load_handles_missing_cache(tmp_path):
+    factors_meta = {
+        "fid_x": {"factor_name": "alpha_x", "factor_expression": "$close",
+                   "ic": 0.05, "rank_ic": 0.06},
+    }
+    lib_path, cache_dir = _build_library(tmp_path, factors_meta, panels={})
+    a = FactorDiversificationAnalyzer(lib_path, cache_dir=cache_dir)
+    n = a.load()
+    assert n == 0
+    assert len(a.records) == 1
+    matrix = a.correlation_matrix()
+    assert matrix.empty or matrix.shape == (0, 0)
+
+
+def test_load_raises_on_missing_library(tmp_path):
+    a = FactorDiversificationAnalyzer(tmp_path / "nope.json")
+    with pytest.raises(FileNotFoundError):
+        a.load()


### PR DESCRIPTION
## Summary

Adds a post-mining analysis step that takes a factor-library JSON (the output of the mining loop) and answers two questions that aren't currently easy to answer:

1. Which factors in my library are basically duplicates of each other?
2. If I want a smaller, well-diversified subset to feed into a combined backtest, which factors should I keep?

The analyzer reuses the existing MD5 factor cache (the `.pkl` files written by `FactorLibraryManager`), so no extra data is needed once mining has run.

## What's in the PR

- `quantaalpha/analysis/correlation.py` - `FactorDiversificationAnalyzer`:
  - Loads factor values from `\$FACTOR_CACHE_DIR` (with a fallback to `result.h5` paths recorded in the library JSON).
  - Computes pairwise mean cross-sectional Spearman rank correlation, the standard quant convention for comparing alpha factors across stocks.
  - Reports redundant pairs above a configurable threshold (default 0.9).
  - Agglomerative clustering on \`1 - |corr|\` for grouping similar factors.
  - Greedy subset selection: highest |Rank IC| first, reject candidates whose max correlation against the already-selected set exceeds \`max_corr\`.
  - \`write_subset_library()\` emits a filtered library JSON that's a drop-in for \`run_backtest.py --factor-json ...\`.

- \`quantaalpha/analysis/run_analysis.py\` - CLI:
  \`\`\`
  python -m quantaalpha.analysis.run_analysis \\
      -j all_factors_library.json \\
      --top 20 --max-corr 0.7 \\
      --write-subset diversified_top20.json
  \`\`\`
  Prints a summary, dumps a full JSON report, and (optionally) writes the filtered library.

- \`frontend-v2/backend/app.py\` - two new endpoints so the dashboard can plug in:
  - \`GET /api/v1/factors/correlation?library=...\` returns the matrix, redundant pairs, clusters.
  - \`POST /api/v1/factors/diversified-subset\` runs the greedy selector and optionally writes a filtered library.

- \`tests/test_correlation.py\` - unit tests against synthetic factor data (no Qlib / LLM needed): perfect / anti-correlated edge cases, duplicate detection, subset selection, clustering, JSON round-trip, missing-cache fallback.

## Why this is useful

Evolutionary mining tends to produce many slight variations of the same idea (e.g. several near-identical RSI variants). Combining all of them in one basket double-counts the same signal and limits diversification gain. Right now the library page lets you filter by IC quality but not by similarity, so you have to eyeball it. This gives you a deterministic pick.

Typical flow:

\`\`\`
# 1. Mine as usual
./run.sh \"Price-Volume Factor Mining\"

# 2. Pick a diversified top-N
python -m quantaalpha.analysis.run_analysis \\
    -j all_factors_library.json --top 20 --max-corr 0.7 \\
    --write-subset diversified_top20.json

# 3. Backtest the subset
python -m quantaalpha.backtest.run_backtest \\
    -c configs/backtest.yaml \\
    --factor-source custom \\
    --factor-json diversified_top20.json
\`\`\`

## Notes

- No new third-party dependencies. \`scikit-learn\` is already in \`requirements.txt\`.
- Factors without cached values are still kept in the report (for ranking) but excluded from the correlation matrix; they can fill the tail of the diversified subset.
- The redundancy / max_corr thresholds are user-tunable both via CLI flags and the API.

## Test plan

- [x] Unit tests pass locally on synthetic data (\`pytest tests/test_correlation.py -v\`)
- [ ] Manual run on a real \`all_factors_library.json\` with the cache warmed
- [ ] Hit \`/api/v1/factors/correlation\` and \`/api/v1/factors/diversified-subset\` from the dashboard backend
- [ ] Round-trip: write subset library -> feed into \`run_backtest.py\` -> compare metrics vs full library